### PR TITLE
fix(ci): unblock nmea-parser 3.0.0 publish (pnpm 11.15.1 + protocol-core build order) + local-CI tooling

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,5 @@
+# nektos/act config — run GitHub Actions locally before merging to main.
+# Installed as a gh extension: `gh act ...`  (docker/podman must be running).
+# Pin the runner image for `ubuntu-latest` (medium image ships Node + npm,
+# which pnpm/action-setup needs for its self-installer).
+-P ubuntu-latest=catthehacker/ubuntu:act-latest

--- a/.github/workflows/nmea-parser.yml
+++ b/.github/workflows/nmea-parser.yml
@@ -31,6 +31,11 @@ jobs:
       - name: 📥 Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      # nmea-parser bundles the private @coremarine/protocol-core (tsup noExternal) and its
+      # tests import it — the core's dist must exist before test/build resolve it.
+      - name: 🛠️ Build monorepo deps
+        run: "pnpm run protocol-core:build"
+
       - name: 🧑‍🔬 Tests
         run: "pnpm run nmea-parser:test"
 
@@ -78,6 +83,11 @@ jobs:
       - name: 📥 Install Dependencies
         if: steps.check.outputs.publish == 'true'
         run: pnpm install --frozen-lockfile
+
+      # Build the bundled private core first (tsup noExternal needs its dist to resolve it).
+      - name: 🛠️ Build monorepo deps
+        if: steps.check.outputs.publish == 'true'
+        run: "pnpm run protocol-core:build"
 
       - name: 🛠️ Build
         if: steps.check.outputs.publish == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ dist
 # Dev helpers (not committed on purpose — see docs/ARCHITECTURE.md)
 misc/
 
-# nektos/act local runner (per-dev tooling — see docs/STATUS.md "test before merge")
-.actrc
+# nektos/act local runner — .actrc is committed (shared runner-image pin);
+# keep secrets and per-dev overrides out of git. See docs/TOOLING.md "Local CI (act)".
 .secrets
 .actrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,8 @@ dist
 
 # Dev helpers (not committed on purpose — see docs/ARCHITECTURE.md)
 misc/
+
+# nektos/act local runner (per-dev tooling — see docs/STATUS.md "test before merge")
+.actrc
+.secrets
+.actrc.local

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -16,6 +16,16 @@ pnpm lint                          # eslint — whole monorepo
 pnpm lint:fix                      # eslint --fix — whole monorepo
 ```
 
+## Local CI (act) — run workflows locally before pushing
+
+```bash
+pnpm run act:list                  # list workflows/jobs act can run (needs docker/podman)
+pnpm run nmea-parser:ci:local      # run nmea-parser's Test job locally via nektos/act
+```
+
+Requires the gh extension once: `gh extension install nektos/gh-act`. Details + raw `gh act`
+usage: [`docs/TOOLING.md`](TOOLING.md) §Local CI (act).
+
 ## Node-RED components
 
 ```bash

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -10,7 +10,7 @@
 > the session: limits hit without warning. Keeping "Where we are now", "Next steps" and "HEAD"
 > current is the entire purpose of this file.
 >
-> **Last updated:** 2026-07-13 · **Branch:** `dev`. **NMEA CMA refactor (slice A–F) +
+> **Last updated:** 2026-07-22 · **Branch:** `dev`. **NMEA CMA refactor (slice A–F) +
 > STEP 1 (3-level metadata) + STEP 2 (Result pattern) + STEP 3 (timestamp metadata, core-wide) are
 > done & green.** Repo was idle 2025-12-15 → 2026-07-08.
 >
@@ -78,6 +78,36 @@ Strokes:
 
 ## Done
 
+- **2026-07-22 — FIX: CI red at `Setup pnpm` — pnpm `11.12.0` is a broken release (cru).** The
+  `dev`→`main` merge was made and **failed on every library workflow at the `📦 Setup pnpm` step**
+  (`pnpm/action-setup@v6`, self-update to the packageManager version): `[ERROR] Cannot use 'in'
+  operator to search for 'integrity' in undefined` while parsing the lockfile. Root cause is **not
+  our logic** — **pnpm `11.12.0` was deprecated by upstream as broken** (`npm view pnpm@11.12.0
+  deprecated` → *"This release is broken. Please upgrade to v11.13.1 or newer."*; `11.13.0` is
+  broken too). It was green on 2026-07-13 because npm deprecated/it surfaced afterward. Same bug hit
+  the **local** dev env (corepack honors the same field). **Fix: bumped root `package.json`
+  `packageManager` `pnpm@11.12.0` → `pnpm@11.15.1`** (current `latest-11`, clean). Lockfile
+  unaffected (packageManager doesn't change dep resolution); `--frozen-lockfile` still clean. Verified
+  local: pnpm 11.15.1, nmea-parser **65/65** + build ESM+CJS+DTS. **The `nmea-parser@3.0.0` publish
+  did NOT happen** (test failed → publish skipped by `needs: test`), so nothing bad shipped — re-merge
+  `dev`→`main` after this lands on `dev` and the `dev` run is green.
+  - **Lesson / process:** the `test`/`build` jobs run on **every `dev` push** (only `publish` is
+    `main`-gated), so **land changes on `dev` and confirm the workflow is green there BEFORE merging
+    to `main`**. `act` (nektos/act) is set up for fully-local workflow runs (Docker/podman present).
+- **2026-07-22 — CI/CD publish-gating re-audited + release plan phased (cru).** No code change
+  (HEAD still `aaa6847`). Audited all 11 workflows: **every publishable package's publish job is
+  correctly gated on `github.ref == 'refs/heads/main'` AND a `npm view <name>@<version>`
+  version-differs check** (publish steps run only when that exact version is NOT yet on npm), each
+  workflow targets **its own** package (no cross-wiring), all on OIDC (`id-token: write`, zero
+  `NPM_TOKEN` — the only "NPM_TOKEN" text is a comment); `protocol-core` correctly has no publish
+  job (private). **Confirmed the only fully-working action today is `nmea-parser`**; `norsub-emru`
+  + `sbg-ecom` test jobs go red on a `main` merge (expected mid-refactor — norsub uses the removed
+  API, sbg has no specs) and `needs: test` blocks their publish, so nothing broken ships. cru
+  **locked the release into strict phases** (see "Where we are now" + the paste-ready prompt):
+  **Phase 1** publish nmea-parser 3.0.0 + verify a fresh install → **Phase 2** (on cru's signal)
+  refactor the nmea-parser-nodered wrapper + verify its CI/CD → **Phase 3** (only once nmea-parser
+  **and** its wrapper are fully in production) norsub-emru + its wrapper → then tblive, then the
+  binary parsers, each with its wrapper. PR message for the `dev`→`main` merge drafted this turn.
 - **2026-07-13 — post-release cleanup + safe dep bumps (cru).** HEAD `ee08691`.
   - **`c39f233` — strip private core from published manifests.** New **`.pnpmfile.mjs`** with a
     `beforePacking` hook that deletes `@coremarine/protocol-core` from any packed package's
@@ -87,9 +117,10 @@ Strokes:
     for local builds; only the *published* manifest is cleaned.)
   - **`b16b7c0` — fixed `thelmabiotel-tblive` `homepage`** (was `github.com/core-marine-dev/tree/…`,
     missing `/devices`).
-  - **`ee08691` — safe dep bumps:** `packageManager` pnpm `11.10.0→11.12.0`, `@types/node`
-    `26.0.1→26.1.1`, `eslint` `10.6.0→10.7.0`. Verified: nmea 65/65, core 14/14, both lint+tsc+build
-    clean, whole-repo `pnpm lint` clean, `--frozen-lockfile` clean.
+  - **`ee08691` — safe dep bumps:** `packageManager` pnpm `11.10.0→11.12.0` (⚠️ **11.12.0 later
+    found broken & deprecated upstream → bumped to `11.15.1` on 2026-07-22**, see the top Done entry),
+    `@types/node` `26.0.1→26.1.1`, `eslint` `10.6.0→10.7.0`. Verified: nmea 65/65, core 14/14, both
+    lint+tsc+build clean, whole-repo `pnpm lint` clean, `--frozen-lockfile` clean.
   - **Deferred deliberately (NOT risk-free — see the CI/CD & versions decisions):**
     - **TypeScript 7** (native Go rewrite, GA 2026-07-08): held at `6.0.3`. TS7 has **no stable
       programmatic API until 7.1** (~Oct 2026); `typescript-eslint@8.63` peers `typescript
@@ -357,7 +388,7 @@ Strokes:
 ## Where we are now
 
 **HEAD `ee08691` (+ this docs commit), branch `dev`, working tree clean (2026-07-13).** Steps 1-6
-complete. Modern stack: pnpm 11.12.0, TypeScript 6.0.3 (TS7 deferred), ESLint 10.7 + sonar +
+complete. Modern stack: pnpm 11.15.1, TypeScript 6.0.3 (TS7 deferred), ESLint 10.7 + sonar +
 perfectionist, Vitest 4, Valibot 1.4.2, zero known vulns on `dev` (the 74 dependabot alerts are on
 `main`, clear on merge).
 
@@ -372,41 +403,66 @@ protocols; `repository.directory` everywhere; nmea-parser is `3.0.0` with protoc
 devDeps + types inlined into the published `.d.ts`. **cru has configured Trusted Publishers on npmjs
 for ALL packages.**
 
-**NEXT — cru opens the PR `dev` → `main`.** Merging publishes via GH Actions. Because of the
-**version gate**, this is now safe/quiet: **only nmea-parser (3.0.0, a new version) actually
-publishes**; every other package's publish job runs the ~2s `npm view` check and **no-ops** (version
-unchanged). norsub-emru + all `-nodered` wrappers fail test/build (broken old API) so their publish
-is skipped anyway. The merge also clears the 74 dependabot alerts on `main`. **After 3.0.0 is live:**
-upgrade `nmea-parser-nodered` (dep → `^3`, re-enable its test/build, fix its `addProtocols`→
-`addSentences` call), then start the `norsub-emru` code refactor.
+**NEXT — the release is PHASED (locked with cru 2026-07-22); do them strictly in order, each fully
+in production before the next:**
+
+- **Phase 1 (current) — publish nmea-parser 3.0.0 + verify a fresh install.** ⚠️ **First merge
+  attempt (2026-07-22) failed** — every library workflow died at `Setup pnpm` because pnpm `11.12.0`
+  is a broken/deprecated release (see top Done entry); **fixed on `dev` by bumping `packageManager`
+  → `pnpm@11.15.1`.** The `3.0.0` publish did NOT happen (test failed → publish skipped), so re-merge
+  is safe. **Next: land the fix on `dev`, confirm the `nmea-parser` workflow is GREEN on `dev`, then
+  cru re-opens/re-merges PR `dev` → `main`** (PR message drafted 2026-07-22). Because of the
+  **version gate** this is safe/quiet: **only nmea-parser 3.0.0 publishes** (OIDC + provenance); every other package's publish
+  job runs the ~2s `npm view` check and **no-ops**; norsub-emru + sbg-ecom test-red is expected and
+  blocks nothing (`needs: test`). The merge also clears the 74 dependabot alerts on `main`. Then
+  **smoke-test a fresh install**: in a clean dir `npm i @coremarine/nmea-parser@3.0.0`, import both
+  ESM + CJS, confirm types resolve and there is **no** `@coremarine/protocol-core` runtime dep.
+- **Phase 2 (only when cru says go, after 3.0.0 is live) — nmea-parser-nodered wrapper.** Dep
+  `@coremarine/nmea-parser` → `^3.0.0`; rewrite `src/parser.js` off the removed `addProtocols(...)`
+  onto `addSentences(yaml)` + CMA output; re-enable its commented-out test job (build the lib dist
+  first); bump version; verify CI/CD green; publish; smoke-test a fresh install.
+- **Phase 3 (only once nmea-parser AND its wrapper are fully in production) — norsub-emru, then its
+  wrapper.** Then thelmabiotel-tblive (+ wrapper), then the binary parsers septentrio-sbf & sbg-ecom
+  (+ wrappers).
 
 ### Prompt for the next agent (paste-ready)
 
 > Continue the CoreMarine **devices** monorepo refactor (branch `dev`, HEAD is a `docs(status)`
-> commit — run `git log --oneline -8` first). Read **`docs/STATUS.md`** top-to-bottom (esp. the top
+> commit — run `git log --oneline -10` first). Read **`docs/STATUS.md`** top-to-bottom (esp. the top
 > Done entries + Decisions). cru works **one step at a time and wants decisions converged BEFORE
-> acting**; verify per package from the package dir; update `docs/STATUS.md` **same-turn**. **Repo
-> rule: for any npm / pnpm / GitHub-Actions specifics, fetch current docs with the `ctx7` CLI — do
-> not rely on memory.**
+> acting**; verify per package from the package dir (lint → tsc → test → build); update
+> `docs/STATUS.md` **same-turn**. **Repo rule: for any npm / pnpm / GitHub-Actions / TypeScript /
+> library specifics, fetch current docs with the `ctx7` CLI — do not rely on memory.**
 >
-> **nmea-parser is a FINISHED library and its 3.0.0 RELEASE is fully prepped + committed on `dev`**
-> (CI/CD on npm OIDC Trusted Publishing with a version gate, version bumped, protocol-core → devDeps,
-> types inlined). Do NOT redo any of that. **The immediate step is cru's own: open PR `dev` → `main`
-> and merge** — the version gate means only nmea-parser 3.0.0 publishes; everything else no-ops or is
-> skipped. If you're driving, help watch the `nmea-parser` workflow's publish job succeed (OIDC +
-> provenance) and confirm `@coremarine/nmea-parser@3.0.0` is on npm.
+> **The release is PHASED (locked 2026-07-22). Do the phases strictly in order — each must be fully
+> in production before starting the next.**
 >
-> **After 3.0.0 is live — nmea-parser-nodered wrapper.** Bump its dep `@coremarine/nmea-parser` →
-> `^3.0.0` (pnpm rewrites `workspace:^` on publish). Its workflow is already on OIDC + the version
-> gate, but its **test job is still commented out** and its `src/parser.js` calls the **removed old
-> API** (`parser.addProtocols({...})`) — update it to `addSentences(yaml)` + CMA output, re-enable
-> the test job (needs the lib's dist built first), bump its version, publish. Trusted Publisher is
-> already configured on npm.
+> **PHASE 1 (current) — publish nmea-parser 3.0.0 & verify a fresh install.** nmea-parser is a
+> FINISHED reference implementation and its 3.0.0 release + repo-wide OIDC/version-gated CI/CD are
+> DONE and committed on `dev` — **do NOT redo any of it.** CI/CD was re-audited 2026-07-22: every
+> package's publish job is correctly gated on `on main` AND `version-differs`, so **only nmea-parser
+> 3.0.0 publishes** on the merge (norsub-emru + sbg-ecom test-red is expected mid-refactor and blocks
+> nothing). **This step is cru's own: open PR `dev` → `main` and merge** (PR message already drafted —
+> see the 2026-07-22 Done entry / ask cru). If you're driving, watch the `nmea-parser` publish job
+> succeed (OIDC + provenance), confirm `@coremarine/nmea-parser@3.0.0` is on npm, then **smoke-test a
+> fresh install**: in a clean dir `npm i @coremarine/nmea-parser@3.0.0`, import both ESM + CJS, confirm
+> types resolve and there is **no** `@coremarine/protocol-core` runtime dep.
 >
-> **THEN norsub-emru** (the next *code* refactor): §"NMEA refactor — locked design & plan" → Resume
+> **PHASE 2 (ONLY when cru says go, after 3.0.0 is live) — nmea-parser-nodered wrapper.** Bump its
+> dep `@coremarine/nmea-parser` → `^3.0.0` (pnpm rewrites `workspace:^` on publish). Its workflow is
+> already on OIDC + the version gate, but its **test job is still commented out** and its
+> `src/parser.js` calls the **removed old API** (`parser.addProtocols({...})`) — rewrite it to
+> `addSentences(yaml)` + CMA output, re-enable the test job (needs the lib's dist built first), bump
+> version, verify CI/CD green, publish, smoke-test a fresh install. Trusted Publisher already
+> configured on npm.
+>
+> **PHASE 3 (ONLY once nmea-parser AND its wrapper are fully in production) — norsub-emru, then its
+> wrapper.** The lib is the next *code* refactor: §"NMEA refactor — locked design & plan" → Resume
 > prompt has the full spec + two open design questions. Its workflow is already modernized (keeps the
 > `Build monorepo deps: nmea-parser:build` step since it extends NMEAParser). Timestamp metadata is
-> inherited from core; no work there. After norsub: thelmabiotel-tblive, then binary parsers
+> inherited from core; no work there. Then norsub-emru-nodered.
+>
+> **LATER (same lib-then-wrapper pattern):** thelmabiotel-tblive, then the binary parsers
 > septentrio-sbf & sbg-ecom (`BinaryParser`, `Buffer`→`Uint8Array`/`DataView`; septentrio will want a
 > `sentenceTimestamp` override for TOW+WNc).
 
@@ -470,7 +526,8 @@ upgrade `nmea-parser-nodered` (dep → `^3`, re-enable its test/build, fix its `
   each wrapper is refactored. Bundled private deps (`@coremarine/protocol-core`) go in
   **devDependencies** (not runtime deps), need tsup `dts.resolve` to inline their TYPES, and are
   stripped from the published manifest by `.pnpmfile.mjs` `beforePacking`.
-- **Toolchain versions (2026-07-13):** node CI = two latest LTS `[22.x, 24.x]`; pnpm `11.12.0`;
+- **Toolchain versions (updated 2026-07-22):** node CI = two latest LTS `[22.x, 24.x]`; pnpm
+  `11.15.1` (was `11.12.0` — that release is broken/deprecated upstream; **avoid 11.12.0 & 11.13.0**);
   **TypeScript held at `6.0.3`** (TS7 native rewrite needs 7.1's stable programmatic API before
   typescript-eslint/tsup work — revisit ~Oct 2026); **js-yaml held at 4.x** (workspace security
   override `js-yaml: '>=4.1.1'` pins it; going to 5 would drag mocha/node-red transitive js-yaml).
@@ -582,10 +639,13 @@ update the `protocols` npm script. Add root proxy scripts if needed.
 
 ## Next steps (in order)
 
-1. **Merge `dev` → `main`** (cru opens the PR) — publishes **nmea-parser 3.0.0** to npm via GH
-   Actions (OIDC + provenance) and clears the dependabot vulnerabilities on `main`. Safe/quiet now:
-   the publish-if-version-changed gate makes every other package's publish job no-op. After it lands,
-   confirm `@coremarine/nmea-parser@3.0.0` is on npm, then do the `nmea-parser-nodered` wrapper.
+1. **Ship the release in PHASES (locked 2026-07-22 — see "Where we are now" for full detail).**
+   **Phase 1 (current):** cru opens PR `dev` → `main` and merges → publishes **nmea-parser 3.0.0**
+   (OIDC + provenance), clears the dependabot alerts on `main`; the version gate no-ops every other
+   package; then smoke-test `npm i @coremarine/nmea-parser@3.0.0` in a clean dir (ESM+CJS import,
+   types resolve, no protocol-core runtime dep). **Phase 2 (on cru's signal):** nmea-parser-nodered
+   wrapper (dep → `^3.0.0`, `addProtocols`→`addSentences`, re-enable test, verify CI/CD, publish).
+   **Phase 3 (only once nmea-parser + its wrapper are fully in production):** norsub-emru + its wrapper.
 2. **CMA rollout** — format is locked; `@coremarine/protocol-core` is scaffolded. Refactor the
    parsers onto it in **cru's order** (easiest-first, NMEA becomes the model):
    1. ~~**nmea-parser**~~ — ✅ DONE (2026-07-10): the reference implementation (CMA rewrite +

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -78,6 +78,23 @@ Strokes:
 
 ## Done
 
+- **2026-07-22 — git history rewritten to strip AI co-author trailers (cru).** cru uses multiple
+  AI agents from different providers and does **not** want any single one credited in authorship.
+  Removed the `Co-Authored-By: Claude …` trailer from all **9** commits that carried it (via
+  `git filter-branch --msg-filter`; messages-only — content byte-identical, `git diff` empty,
+  topology preserved). Force-pushed **both** branches: `origin/dev` `2811a4b→02c3e3a`, `origin/main`
+  `d2d8a28→0f0191c`; remote verified 0 trailers. Also set globally in `~/.claude/settings.json`:
+  `attribution.commit=""`, `attribution.pr=""`, `attribution.sessionUrl=false`,
+  `includeCoAuthoredBy=false` (Claude Code adds no attribution anywhere, all repos, going forward).
+  **⚠️ Consequences for the next agent:**
+  - **All commit SHAs changed.** Every short hash cited in the Done entries below (`ee08691`,
+    `65bec81`, `c39f233`, etc.) is a **pre-rewrite** reference and **no longer resolves** on the
+    branches — treat them as historical labels, not lookups. Current tips: `dev` `02c3e3a`,
+    `main` `0f0191c`.
+  - **Anyone with an existing clone must** `git fetch origin && git reset --hard origin/<branch>`
+    before working, or they'll re-push the old history.
+  - **GitHub still retains the old SHAs** via the merged PR's `refs/pull/*` + caches (force-push
+    can't purge those; would need GH Support or repo recreate). Nothing was on npm, so no pkg impact.
 - **2026-07-22 — FIX: nmea-parser CI couldn't resolve the private core in a fresh checkout (cru).**
   After the pnpm fix, running the workflow locally with **`act`** surfaced a *second*, pre-existing
   break: nmea-parser's tests/build import `@coremarine/protocol-core`, whose `package.json`

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -78,6 +78,22 @@ Strokes:
 
 ## Done
 
+- **2026-07-22 — FIX: nmea-parser CI couldn't resolve the private core in a fresh checkout (cru).**
+  After the pnpm fix, running the workflow locally with **`act`** surfaced a *second*, pre-existing
+  break: nmea-parser's tests/build import `@coremarine/protocol-core`, whose `package.json`
+  `exports`/`main` point **only at `dist/`** — and the workflow built **nothing** before Tests. In a
+  fresh checkout the core has no `dist/`, so vitest died with *"Failed to resolve entry for package
+  @coremarine/protocol-core"* (4 suites). It only ever passed locally because a prior session left
+  `packages/core/dist/` on disk. **This had been red in CI since the 2026-07-10 core refactor** — the
+  pnpm bug just failed earlier and hid it. **Fix (Option A, cru): added a `🛠️ Build monorepo deps`
+  step running `pnpm run protocol-core:build`** to `nmea-parser.yml` — before Tests in the test job,
+  and before Build in the publish job (mirrors the `norsub-emru.yml` "build nmea-parser first"
+  pattern). Reproduced + fixed locally (rm core dist → 4 fail; build core → 65/65) and **re-verified
+  end-to-end with `act` from a clean checkout: Setup pnpm ✅ → protocol-core build ✅ → 65/65 ✅ →
+  nmea build ✅ → job succeeded.** Follow-ups noted for later: (B) a `pretest` hook, or (C) resolve
+  the core from source (`exports`→`src`/vitest alias) to drop the build-order dep repo-wide — revisit
+  when refactoring norsub. **Local dev gotcha remains:** run `pnpm run protocol-core:build` once
+  before `nmea-parser:test` if `packages/core/dist/` is absent.
 - **2026-07-22 — FIX: CI red at `Setup pnpm` — pnpm `11.12.0` is a broken release (cru).** The
   `dev`→`main` merge was made and **failed on every library workflow at the `📦 Setup pnpm` step**
   (`pnpm/action-setup@v6`, self-update to the packageManager version): `[ERROR] Cannot use 'in'

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -31,6 +31,33 @@ Current CI gaps (as committed):
 - All 5 **nodered workflows have the whole `test` job commented out** — they publish untested.
 - `sbg-ecom.yml` has its test step commented out (package has no test specs yet).
 
+## Local CI (act) — test workflows before pushing
+
+[`nektos/act`](https://github.com/nektos/act) runs the GitHub Actions workflows **locally in a
+container**, so you can confirm a workflow is green before pushing/merging (only `publish`, which
+needs OIDC on `main`, can't run locally). This is the guard that would have caught both the
+pnpm-`11.12.0` break and the `protocol-core` build-order break before they ever reached `main`.
+
+- **Requires:** a running container engine (Docker **or** Podman) — nothing else.
+- **Install (once):** `gh extension install nektos/gh-act` → invoke as `gh act …`.
+  (Fedora's `dnf` `act` is an unrelated tool; don't use it.)
+- **Config:** committed **`.actrc`** pins the runner image
+  (`-P ubuntu-latest=catthehacker/ubuntu:act-latest` — medium image, ships Node+npm which
+  `pnpm/action-setup` needs). First run pulls ~1.6 GB, then it's cached. `.secrets` /
+  `.actrc.local` stay git-ignored for per-dev overrides.
+
+```bash
+pnpm run act:list                 # list all workflows/jobs act can see
+pnpm run nmea-parser:ci:local     # run nmea-parser's Test job locally (both node LTS)
+# raw, for anything else:
+gh act push -W .github/workflows/<pkg>.yml -j test           # one workflow's test job
+gh act push -W .github/workflows/nmea-parser.yml -j test --matrix node-version:24.x  # one matrix entry (faster)
+```
+
+`act` starts from a **clean checkout** (git-ignored `dist/` is absent), so it faithfully
+reproduces fresh-CI resolution — which is exactly why it surfaces missing build-order steps that a
+dirty local tree hides. Add a `<pkg>:ci:local` script per package as each one's workflow goes green.
+
 ## Templates (`templates/`)
 
 Scaffolding for new packages — see CONTRIBUTING.md for the step-by-step recipes:

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "nmea-parser:build": "pnpm --filter @coremarine/nmea-parser run build",
     "nmea-parser:test": "pnpm --filter @coremarine/nmea-parser run test",
     "nmea-parser:test:coverage": "pnpm --filter @coremarine/nmea-parser run test:coverage",
+    "nmea-parser:ci:local": "gh act push -W .github/workflows/nmea-parser.yml -j test",
     "nmea-parser:nodered:docker": "pnpm --filter @coremarine/nmea-parser-nodered run docker",
     "nmea-parser:nodered:test": "pnpm --filter @coremarine/nmea-parser-nodered run test",
     "norsub-emru:lint": "pnpm --filter @coremarine/norsub-emru run lint",
@@ -78,7 +79,8 @@
     "thelmabiotel-tblive:nodered:docker": "pnpm --filter @coremarine/thelmabiotel-tblive-nodered run docker",
     "thelmabiotel-tblive:nodered:test": "pnpm --filter @coremarine/thelmabiotel-tblive-nodered run test",
     "lint": "eslint",
-    "lint:fix": "eslint --fix"
+    "lint:fix": "eslint --fix",
+    "act:list": "gh act -l"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript"
   ],
   "type": "module",
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.15.1",
   "scripts": {
     "protocol-core:lint": "pnpm --filter @coremarine/protocol-core run lint",
     "protocol-core:format": "pnpm --filter @coremarine/protocol-core run format",


### PR DESCRIPTION
## Why

The 3.0.0 release code is already on `main` (PR #67), but its publish never ran — CI died
before the publish job. This PR carries the two fixes that make the nmea-parser workflow green
in a fresh runner, so 3.0.0 can be published, plus tooling to test workflows locally.

## Fixes

- **pnpm `11.12.0` → `11.15.1`** (`packageManager`). 11.12.0 is a broken release, deprecated
  upstream (*"This release is broken. Please upgrade to v11.13.1 or newer"*); it made every
  library workflow fail at `Setup pnpm` (`Cannot use 'in' operator … 'integrity'`). Lockfile
  unaffected; `--frozen-lockfile` clean.
- **Build `@coremarine/protocol-core` before nmea-parser test/build** in `nmea-parser.yml`. The
  private core is bundled via tsup `noExternal` and imported by the tests, but its `exports`
  point only at `dist/`, which doesn't exist in a fresh checkout — 4 suites failed to resolve it.
  Added a `Build monorepo deps` step (test job before Tests; publish job before Build), mirroring
  the existing `norsub-emru.yml` pattern.

## Tooling / docs

- Local CI via `nektos/act`: committed `.actrc` (pinned runner image), scripts
  `nmea-parser:ci:local` + `act:list`, documented in `docs/TOOLING.md` / `docs/COMMANDS.md`.
- `docs/STATUS.md` updated (phased release plan, CI re-audit, these fixes).

## Verification

- `nmea-parser` test job verified green on GitHub CI (dev, Node 22.x + 24.x) and end-to-end via
  `act` from a clean checkout: Setup pnpm → protocol-core build → 65/65 tests → nmea build.
- Expected reds (unchanged, by design, blocked from publishing by `needs: test`): `norsub-emru`
  (old API) and `sbg-ecom` (no specs).

## After merge

This diff doesn't touch `packages/nmea-parser/**`, so the merge won't auto-trigger the workflow.
Publish 3.0.0 with a manual run on `main`: Actions → nmea-parser → Run workflow (branch `main`),
or `gh workflow run nmea-parser.yml --ref main`. The version gate (npm has 2.2.1) opens and it
publishes 3.0.0 via OIDC + provenance.